### PR TITLE
fix: add base path to vite config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "rm -rf dist && vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 export default defineConfig({
+  base: './',
   plugins: [svelte({
     configFile: 'svelte.config.js'
   })],


### PR DESCRIPTION
Fixes https://github.com/Parthipan-Natkunam/basic-social-text-formatter/issues/2

Adding `base`  as `./` in the vite build config file.